### PR TITLE
add better fix for bootstrap's jquery deps error

### DIFF
--- a/build/bundles.js
+++ b/build/bundles.js
@@ -33,8 +33,7 @@ module.exports = {
         "aurelia-logging-console",
         "bootstrap",
         "bootstrap/css/bootstrap.css!text",
-        "jquery",
-        "jquery/dist/jquery.min"
+        "jquery"
       ],
       "options": {
         "inject": true,

--- a/config.js
+++ b/config.js
@@ -6,7 +6,13 @@ System.config({
     "github:*": "jspm_packages/github/*",
     "npm:*": "jspm_packages/npm/*"
   },
-
+  meta: {
+    "bootstrap": {
+      "deps": [
+        "jquery"
+      ]
+    }
+  },
   map: {
     "aurelia-animator-css": "npm:aurelia-animator-css@1.0.0-beta.1.2.0",
     "aurelia-bootstrapper": "npm:aurelia-bootstrapper@1.0.0-beta.1.2.0",


### PR DESCRIPTION
The 'gulp export' command should still work.